### PR TITLE
Run in library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Pies
+/*.zip

--- a/src/hints/fact_topologies.rs
+++ b/src/hints/fact_topologies.rs
@@ -390,7 +390,7 @@ pub fn get_task_fact_topology(
             }
         };
 
-        get_fact_topology_from_additional_data(output_size, additional_data)
+        get_fact_topology_from_additional_data(output_size, &additional_data)
     } else {
         Err(FactTopologyError::Internal("Unexpected task type".to_string().into_boxed_str()))
     }
@@ -513,9 +513,8 @@ mod tests {
             offset: 10,
         };
 
-        let result = configure_fact_topologies(&fact_topologies, &mut output_start, &mut output_builtin, true)
+        configure_fact_topologies(&fact_topologies, &mut output_start, &mut output_builtin, true)
             .expect("Configuring fact topologies failed unexpectedly");
-        assert_eq!(result, ());
 
         let output_builtin_state = output_builtin.get_state();
         assert_eq!(output_builtin_state.base, 0);
@@ -537,10 +536,8 @@ mod tests {
             offset: 10,
         };
 
-        let result = configure_fact_topologies(&fact_topologies, &mut output_start, &mut output_builtin, false)
+        configure_fact_topologies(&fact_topologies, &mut output_start, &mut output_builtin, false)
             .expect("Configuring fact topologies failed unexpectedly");
-
-        assert_eq!(result, ());
 
         // We expect the offset to 2 + sum(page_sizes) for each fact topology
         let expected_offset: usize = fact_topologies.iter().flat_map(|ft| &ft.page_sizes).sum();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bootloaders;
 pub mod error;
 pub mod hints;
+pub mod run;
 pub mod tasks;
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,107 +1,11 @@
-use cairo_vm::{
-    cairo_run,
-    cairo_run::cairo_run_program_with_initial_scope,
-    types::{exec_scope::ExecutionScopes, layout_name::LayoutName},
-    Felt252,
+use cairo_bootloader::{
+    error::Error,
+    run::{run_bootloader, RunBootloaderArgs},
 };
-use clap::{Parser, ValueHint};
-use error::Error;
-use tasks::{insert_bootloader_input, make_bootloader_tasks};
-use tracing::debug;
-
-use crate::{
-    bootloaders::load_bootloader,
-    hints::{BootloaderConfig, BootloaderHintProcessor, BootloaderInput, PackedOutput, SimpleBootloaderInput},
-};
-
-pub mod bootloaders;
-pub mod error;
-pub mod hints;
-pub mod tasks;
-
-#[cfg(test)]
-pub mod macros;
-
-use std::path::PathBuf;
-
-#[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
-pub struct RunBootloaderArgs {
-    #[clap(long = "cairo_pies", value_hint=ValueHint::FilePath, value_delimiter = ' ', num_args = 1..)]
-    pub cairo_pies: Option<Vec<PathBuf>>,
-
-    #[clap(long = "layout", default_value = "all_cairo", value_enum)]
-    pub layout: LayoutName,
-
-    #[structopt(long = "secure_run")]
-    secure_run: Option<bool>,
-
-    #[clap(long = "cairo_pie_output")]
-    cairo_pie_output: Option<PathBuf>,
-
-    #[clap(long = "fact_topologies_output", default_value = "./fact_topologies.json", value_hint=ValueHint::FilePath, help = "Output of bootloader required along with bootloader_proof.json to split proofs for Ethereum")]
-    pub fact_topologies_output: PathBuf,
-
-    #[clap(
-        long = "ignore_fact_topologies",
-        help = "Option to ignore fact topologies, which will result in task outputs being written only to public memory page 0"
-    )]
-    pub ignore_fact_topologies: bool,
-
-    #[structopt(long = "allow_missing_builtins")]
-    allow_missing_builtins: Option<bool>,
-}
+use clap::Parser;
 
 fn main() -> Result<(), Error> {
-    tracing_subscriber::fmt::init();
-
     let args = RunBootloaderArgs::try_parse_from(std::env::args()).map_err(Error::Cli)?;
 
-    // Init CairoRunConfig
-    let cairo_run_config = cairo_run::CairoRunConfig {
-        trace_enabled: true,
-        relocate_mem: true,
-        layout: args.layout,
-        proof_mode: false,
-        secure_run: args.secure_run,
-        allow_missing_builtins: args.allow_missing_builtins,
-        ..Default::default()
-    };
-
-    let tasks = make_bootloader_tasks(None, None, args.cairo_pies.as_deref()).unwrap();
-
-    // Build the bootloader input
-    let n_tasks = tasks.len();
-    let bootloader_input = BootloaderInput {
-        simple_bootloader_input: SimpleBootloaderInput {
-            fact_topologies_path: None,
-            single_page: false,
-            tasks,
-        },
-        bootloader_config: BootloaderConfig {
-            simple_bootloader_program_hash: Felt252::from(0),
-            supported_cairo_verifier_program_hashes: vec![],
-        },
-        packed_outputs: vec![PackedOutput::Plain(vec![]); n_tasks],
-        ignore_fact_topologies: args.ignore_fact_topologies,
-    };
-
-    let mut exec_scopes = ExecutionScopes::new();
-    insert_bootloader_input(&mut exec_scopes, bootloader_input);
-
-    let bootloader_program = load_bootloader()?;
-
-    let mut hint_processor = BootloaderHintProcessor::new();
-    let cairo_runner = cairo_run_program_with_initial_scope(&bootloader_program, &cairo_run_config, &mut hint_processor, exec_scopes)?;
-
-    debug!("{:?}", cairo_runner.get_execution_resources());
-
-    if let Some(ref file_name) = args.cairo_pie_output {
-        cairo_runner
-            .get_cairo_pie()
-            .map_err(|e| Error::CairoPie(e.to_string()))?
-            .write_zip_file(file_name)?
-    }
-
-    Ok(())
+    run_bootloader(args)
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,0 +1,97 @@
+use std::path::PathBuf;
+
+use cairo_vm::{
+    cairo_run,
+    cairo_run::cairo_run_program_with_initial_scope,
+    types::{exec_scope::ExecutionScopes, layout_name::LayoutName},
+    Felt252,
+};
+use clap::{Parser, ValueHint};
+use tracing::debug;
+
+use crate::{
+    bootloaders::load_bootloader,
+    error::Error,
+    hints::{BootloaderConfig, BootloaderHintProcessor, BootloaderInput, PackedOutput, SimpleBootloaderInput},
+    tasks::{insert_bootloader_input, make_bootloader_tasks},
+};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct RunBootloaderArgs {
+    #[clap(long = "cairo_pies", value_hint=ValueHint::FilePath, value_delimiter = ' ', num_args = 1..)]
+    pub cairo_pies: Option<Vec<PathBuf>>,
+
+    #[clap(long = "layout", default_value = "all_cairo", value_enum)]
+    pub layout: LayoutName,
+
+    #[structopt(long = "secure_run")]
+    secure_run: Option<bool>,
+
+    #[clap(long = "cairo_pie_output")]
+    cairo_pie_output: Option<PathBuf>,
+
+    #[clap(long = "fact_topologies_output", default_value = "./fact_topologies.json", value_hint=ValueHint::FilePath, help = "Output of bootloader required along with bootloader_proof.json to split proofs for Ethereum")]
+    pub fact_topologies_output: PathBuf,
+
+    #[clap(
+        long = "ignore_fact_topologies",
+        help = "Option to ignore fact topologies, which will result in task outputs being written only to public memory page 0"
+    )]
+    pub ignore_fact_topologies: bool,
+
+    #[structopt(long = "allow_missing_builtins")]
+    allow_missing_builtins: Option<bool>,
+}
+
+pub fn run_bootloader(args: RunBootloaderArgs) -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+
+    // Init CairoRunConfig
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        trace_enabled: true,
+        relocate_mem: true,
+        layout: args.layout,
+        proof_mode: false,
+        secure_run: args.secure_run,
+        allow_missing_builtins: args.allow_missing_builtins,
+        ..Default::default()
+    };
+
+    let tasks = make_bootloader_tasks(None, None, args.cairo_pies.as_deref()).unwrap();
+
+    // Build the bootloader input
+    let n_tasks = tasks.len();
+    let bootloader_input = BootloaderInput {
+        simple_bootloader_input: SimpleBootloaderInput {
+            fact_topologies_path: None,
+            single_page: false,
+            tasks,
+        },
+        bootloader_config: BootloaderConfig {
+            simple_bootloader_program_hash: Felt252::from(0),
+            supported_cairo_verifier_program_hashes: vec![],
+        },
+        packed_outputs: vec![PackedOutput::Plain(vec![]); n_tasks],
+        ignore_fact_topologies: args.ignore_fact_topologies,
+    };
+
+    let mut exec_scopes = ExecutionScopes::new();
+    insert_bootloader_input(&mut exec_scopes, bootloader_input);
+
+    let bootloader_program = load_bootloader()?;
+
+    let mut hint_processor = BootloaderHintProcessor::new();
+    let cairo_runner = cairo_run_program_with_initial_scope(&bootloader_program, &cairo_run_config, &mut hint_processor, exec_scopes)?;
+
+    debug!("{:?}", cairo_runner.get_execution_resources());
+
+    if let Some(ref file_name) = args.cairo_pie_output {
+        cairo_runner
+            .get_cairo_pie()
+            .map_err(|e| Error::CairoPie(e.to_string()))?
+            .write_zip_file(file_name)?
+    }
+
+    Ok(())
+}

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,11 +1,7 @@
 use std::path::PathBuf;
 
-use cairo_vm::{
-    cairo_run,
-    cairo_run::cairo_run_program_with_initial_scope,
-    types::{exec_scope::ExecutionScopes, layout_name::LayoutName},
-    Felt252,
-};
+pub use cairo_vm::types::layout_name::LayoutName;
+use cairo_vm::{cairo_run, cairo_run::cairo_run_program_with_initial_scope, types::exec_scope::ExecutionScopes, Felt252};
 use clap::{Parser, ValueHint};
 use tracing::debug;
 
@@ -26,10 +22,10 @@ pub struct RunBootloaderArgs {
     pub layout: LayoutName,
 
     #[structopt(long = "secure_run")]
-    secure_run: Option<bool>,
+    pub secure_run: Option<bool>,
 
     #[clap(long = "cairo_pie_output")]
-    cairo_pie_output: Option<PathBuf>,
+    pub cairo_pie_output: Option<PathBuf>,
 
     #[clap(long = "fact_topologies_output", default_value = "./fact_topologies.json", value_hint=ValueHint::FilePath, help = "Output of bootloader required along with bootloader_proof.json to split proofs for Ethereum")]
     pub fact_topologies_output: PathBuf,
@@ -41,7 +37,7 @@ pub struct RunBootloaderArgs {
     pub ignore_fact_topologies: bool,
 
     #[structopt(long = "allow_missing_builtins")]
-    allow_missing_builtins: Option<bool>,
+    pub allow_missing_builtins: Option<bool>,
 }
 
 pub fn run_bootloader(args: RunBootloaderArgs) -> Result<(), Error> {

--- a/src/run.rs
+++ b/src/run.rs
@@ -27,14 +27,11 @@ pub struct RunBootloaderArgs {
     #[clap(long = "cairo_pie_output")]
     pub cairo_pie_output: Option<PathBuf>,
 
-    #[clap(long = "fact_topologies_output", default_value = "./fact_topologies.json", value_hint=ValueHint::FilePath, help = "Output of bootloader required along with bootloader_proof.json to split proofs for Ethereum")]
-    pub fact_topologies_output: PathBuf,
-
     #[clap(
         long = "ignore_fact_topologies",
         help = "Option to ignore fact topologies, which will result in task outputs being written only to public memory page 0"
     )]
-    pub ignore_fact_topologies: bool,
+    pub ignore_fact_topologies: Option<bool>,
 
     #[structopt(long = "allow_missing_builtins")]
     pub allow_missing_builtins: Option<bool>,
@@ -69,7 +66,7 @@ pub fn run_bootloader(args: RunBootloaderArgs) -> Result<(), Error> {
             supported_cairo_verifier_program_hashes: vec![],
         },
         packed_outputs: vec![PackedOutput::Plain(vec![]); n_tasks],
-        ignore_fact_topologies: args.ignore_fact_topologies,
+        ignore_fact_topologies: args.ignore_fact_topologies.unwrap_or(false),
     };
 
     let mut exec_scopes = ExecutionScopes::new();


### PR DESCRIPTION
- resolved errors in `src/hints/fact_topologies.rs` - can be skipped
- added pies to `.gitignore`
- moved running part to be a part of the library: `src/run.rs`
  - makes it easier to use the project as a lib in rust