### PR TITLE
added "clap" cairo-vm feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 clap = { version = "4.3.10", features = ["derive"] }
 cairo-vm = { git = "https://github.com/zksecurity/cairo-vm.git", features = [
     "extensive_hints",
+    "clap",
 ], rev = "ac8b81b79f65f5017fe0929bf4025be4a0e9c73c" }
 num-traits = "0.2.19"
 serde = { version = "1.0.202", features = ["derive"] }


### PR DESCRIPTION
- "clap" `cairo-vm` feature was deleted in the merge commit: https://github.com/Okm165/cairo-bootloader/commit/bc2e2cd47df86cddaaaead1a3fc8829b7c70861b
- the repo didn't build without it
- brought it back
